### PR TITLE
Ajout de la pagination côté client sur la page des projets

### DIFF
--- a/app/routes/projects/index.tsx
+++ b/app/routes/projects/index.tsx
@@ -2,6 +2,7 @@ import { useLoaderData } from "react-router";
 import type { Route } from "./+types";
 import type { Project } from "~/type";
 import ProjectCard from "~/component/ProjectCard";
+import { useState } from "react";
 
 export async function loader({
   request,
@@ -13,15 +14,42 @@ export async function loader({
 
 const ProjectsPage = ({ loaderData }: Route.ComponentProps) => {
   const { projects } = loaderData as { projects: Project[] };
-  console.log(projects);
+
+  const [currentPage, SetCurrentPage] = useState(1);
+  const projectPerPage = 2;
+
+  //Calculate total Pages
+  const totalPages = Math.ceil(projects.length / projectPerPage);
+
+  //Get Current Page Project
+  const indexOfLast = currentPage * projectPerPage;
+  const indexOfFirst = indexOfLast - projectPerPage;
+  const currentProjects = projects.slice(indexOfFirst, indexOfLast);
+
+  // Pagination Button Render
+  const renderPagination = () => (
+    <div className="flex justify-center gap-2 mt-8 ">
+      {Array.from({ length: totalPages }, (_, idx) => (
+        <button
+          key={idx + 1}
+          className={`px-3 py-1 cursor-pointer rounded ${currentPage === idx + 1 ? "bg-blue-600 text-white" : "bg-gray-700 text-gray-200"}`}
+          onClick={() => SetCurrentPage(idx + 1)}
+        >
+          {idx + 1}
+        </button>
+      ))}
+    </div>
+  );
+
   return (
     <>
-      <h2 className="text-3xl font-bold text-white mb-8 ">Project Page</h2>
+      <h2 className="text-3xl font-bold text-white mb-8 ">Projects</h2>
       <div className="grid gap-6 sm:grid-cols-2 ">
-        {projects.map((project) => (
+        {currentProjects.map((project) => (
           <ProjectCard key={project.id} project={project} />
         ))}
       </div>
+      {totalPages > 1 && renderPagination()}
     </>
   );
 };


### PR DESCRIPTION
## Description
Cette pull request introduit une pagination côté client sur la page listant les projets.

Les données étant récupérées via un loader, la pagination est gérée exclusivement au niveau de l’interface à l’aide de l’état React, sans appel réseau supplémentaire.

## Changements apportés
- Ajout d’un état pour suivre la page courante
- Définition d’un nombre fixe de projets par page
- Calcul dynamique du nombre total de pages
- Découpage des projets affichés via `Array.slice`
- Génération dynamique des boutons de pagination
- Mise en évidence de la page active
- Rendu conditionnel de la pagination

## Pourquoi ce choix
- Amélioration de l’expérience utilisateur
- Navigation fluide sans rechargement
- Simplicité et performance pour un volume de données raisonnable
- Séparation claire entre la récupération des données et la logique d’affichage